### PR TITLE
Fix maximum recursion depths in certain testing environments.

### DIFF
--- a/collective/lastmodifier/patches.py
+++ b/collective/lastmodifier/patches.py
@@ -14,5 +14,7 @@ def notifyModified(self):
 
 
 def applyPatch(scope, original, replacement):
-    setattr(scope, '_original_' + original, getattr(scope, original))
+    original_backup_name = '_original_' + original
+    if getattr(scope, original_backup_name, None) is None:
+        setattr(scope, original_backup_name, getattr(scope, original))
     setattr(scope, original, replacement)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,10 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix maximum recursion depths in certain testing environments.
+  This is caused by applying the patch multiple times when the ZCML is
+  loaded multiple times.
+  [jone]
 
 
 1.0 (2012-08-15)


### PR DESCRIPTION
This is caused by applying the patch multiple times when the ZCML is loaded multiple times.

@buchi this fixes the `maximum recursion depth` errors when multiple testing layers are used, which load the ZCML.
This is not a problem in the tests of `collective.lastmodifier`, but in tests of integration packages..
