### PR TITLE
Use IDexterityContent instead of IDexterityItem

### DIFF
--- a/collective/lastmodifier/configure.zcml
+++ b/collective/lastmodifier/configure.zcml
@@ -30,16 +30,16 @@
 
     <configure zcml:condition="installed plone.app.dexterity">
       <adapter factory=".adapter.DXLastModifier"
-               for="plone.dexterity.interfaces.IDexterityItem" />
+               for="plone.dexterity.interfaces.IDexterityContent" />
 
       <subscriber
-          for="plone.dexterity.interfaces.IDexterityItem
+          for="plone.dexterity.interfaces.IDexterityContent
                zope.lifecycleevent.interfaces.IObjectAddedEvent"
           handler=".subscribers.set_last_modifier"
           />
 
       <subscriber
-          for="plone.dexterity.interfaces.IDexterityItem
+          for="plone.dexterity.interfaces.IDexterityContent
                zope.lifecycleevent.interfaces.IObjectModifiedEvent"
           handler=".subscribers.set_last_modifier"
           />

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use IDexterityContent instead of IDexterityItem to match all dexterity
+  contents.
+  [cedricmessiant]
 
 
 1.1.1 (2014-09-05)


### PR DESCRIPTION
Use IDexterityContent instead of IDexterityItem to match all dexterity contents and not only non containers objects.
